### PR TITLE
Add type definitions to exports for better typescript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,16 +12,32 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/mjs/index.d.ts",
       "import": "./dist/mjs/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./async": {
+      "types": "./dist/mjs/async.d.ts",
       "import": "./dist/mjs/async.js",
       "require": "./dist/cjs/async.js"
     },
     "./memo": {
+      "types": "./dist/mjs/memo.d.ts",
       "import": "./dist/mjs/memo.js",
       "require": "./dist/cjs/memo.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/mjs/index.d.ts"
+      ],
+      "async": [
+        "./dist/mjs/async.d.ts"
+      ],
+      "memo": [
+        "./dist/mjs/memo.d.ts"
+      ]
     }
   },
   "scripts": {


### PR DESCRIPTION
Due to missing fields in the package.json, imports from /async and /memo would not be typed, leading to problems in typescript projects. Here, we add the missing declarations.