### PR TITLE
Enable parallel execution of async computations

### DIFF
--- a/src/async.test.ts
+++ b/src/async.test.ts
@@ -2,6 +2,10 @@ import cogniAsync from './async';
 
 jest.useFakeTimers();
 
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 describe('cogniAsync', () => {
   it('should compute basic operation with a synchronous ComputeFunction', async () => {
     const { define, get } = cogniAsync<{}, { result: number }>();
@@ -12,7 +16,10 @@ describe('cogniAsync', () => {
   });
 
   it('should handle dependency computation', async () => {
-    const { define, get } = cogniAsync<{ base: number }, { double: number, triple: number }>();
+    const { define, get } = cogniAsync<
+      { base: number },
+      { double: number; triple: number }
+    >();
 
     define('double', async ({ base }) => base * 2);
     define('triple', async ({ base }) => base * 3);
@@ -22,17 +29,26 @@ describe('cogniAsync', () => {
   });
 
   it('should manage complex dependency tree computations', async () => {
-    const { define, get } = cogniAsync<{ a: number, b: number }, { sum: number, product: number, combined: number }>();
+    const { define, get } = cogniAsync<
+      { a: number; b: number },
+      { sum: number; product: number; combined: number }
+    >();
 
     define('sum', async ({ a, b }) => a + b);
     define('product', async ({ a, b }) => a * b);
-    define('combined', async (params, { sum, product }) => sum + product, ['sum', 'product']);
+    define('combined', async (params, { sum, product }) => sum + product, [
+      'sum',
+      'product',
+    ]);
 
     await expect(get('combined', { a: 2, b: 3 })).resolves.toBe(11); // (2 + 3) + (2 * 3)
   });
 
   it('should return multiple values with getMany', async () => {
-    const { define, getMany } = cogniAsync<{ value: number }, { double: number, square: number }>();
+    const { define, getMany } = cogniAsync<
+      { value: number },
+      { double: number; square: number }
+    >();
 
     define('double', async ({ value }) => value * 2);
     define('square', async ({ value }) => value * value);
@@ -44,7 +60,10 @@ describe('cogniAsync', () => {
   });
 
   it('should execute parent compute function only once when multiple children depend on it', async () => {
-    const { define, getMany } = cogniAsync<{}, { parent: number, child1: number, child2: number }>();
+    const { define, getMany } = cogniAsync<
+      {},
+      { parent: number; child1: number; child2: number }
+    >();
 
     // Creating a mock function for the parent compute function
     const mockParentFunction = jest.fn().mockResolvedValue(10);
@@ -67,16 +86,15 @@ describe('cogniAsync', () => {
     const { define, get } = cogniAsync<{}, { delayedResult: number }>();
 
     // Define a function that resolves after a delay
-    define('delayedResult', () => {
-      return new Promise((resolve) => {
-        setTimeout(() => resolve(100), 1000); // Resolve after 1 second
-      });
+    define('delayedResult', async () => {
+      await delay(1000);
+      return 100;
     });
 
     const promise = get('delayedResult', {});
 
     // Fast-forward time by 1 second
-    jest.advanceTimersByTime(1000);
+    await jest.advanceTimersByTimeAsync(1000);
 
     // Await the result after advancing the timers
     const result = await promise;
@@ -85,7 +103,10 @@ describe('cogniAsync', () => {
   });
 
   it('should handle concurrent computations correctly', async () => {
-    const { define, getMany } = cogniAsync<{}, { first: number, second: number }>();
+    const { define, getMany } = cogniAsync<
+      {},
+      { first: number; second: number }
+    >();
 
     define('first', async () => 1);
     define('second', async () => 2);
@@ -95,7 +116,10 @@ describe('cogniAsync', () => {
   });
 
   it('should resolve dependencies in the correct sequential order', async () => {
-    const { define, get } = cogniAsync<{}, { first: string, second: string, combined: string }>();
+    const { define, get } = cogniAsync<
+      {},
+      { first: string; second: string; combined: string }
+    >();
 
     const order: string[] = [];
 
@@ -109,7 +133,11 @@ describe('cogniAsync', () => {
       return 'Second';
     });
 
-    define('combined', async (params, { first, second }) => `${first} and ${second}`, ['first', 'second']);
+    define(
+      'combined',
+      async (params, { first, second }) => `${first} and ${second}`,
+      ['first', 'second'],
+    );
 
     await get('combined', {});
 
@@ -128,7 +156,7 @@ describe('cogniAsync', () => {
 
   test('should throw error when defining a value with undefined parent value', () => {
     type Params = { base: number };
-    type Results = { double: number, triple: number };
+    type Results = { double: number; triple: number };
 
     const { define } = cogniAsync<Params, Results>();
 
@@ -149,5 +177,36 @@ describe('cogniAsync', () => {
 
     // Expect the promise to reject and check if the error message is correct
     await expect(get('errorResult', {})).rejects.toThrow('Intentional failure');
+  });
+
+  it('should compute parallelizable operations in parallel', async () => {
+    const { define, get } = cogniAsync<
+      {},
+      { a: string; b: string; c: string }
+    >();
+
+    define('a', async () => {
+      await delay(1000);
+      return 'A';
+    });
+
+    define('b', async () => {
+      await delay(1000);
+      return 'B';
+    });
+
+    define(
+      'c',
+      (_, { a, b }) => {
+        return `${a} ${b}`;
+      },
+      ['a', 'b'],
+    );
+
+    const result = get('c', {});
+
+    await jest.advanceTimersByTimeAsync(1000);
+
+    await expect(result).resolves.toBe('A B');
   });
 });

--- a/src/async.ts
+++ b/src/async.ts
@@ -243,11 +243,8 @@ function cogniAsync<
     param: TParam,
     results: AsyncResultObject<TResult> = {} as AsyncResultObject<TResult>,
   ): Promise<ResultObject<TResult>> {
-    const myResults: Array<Promise<[keyof TResult, TResult[keyof TResult]]>> =
-      [];
     // Iterate over keys.
-    for (const key of keys) {
-      // Check if the key has already been resolved.
+    const myResults = keys.map(async (key) => {
       if (!results[key]) {
         // Resolve the key and cache the result.
         results[key] = getInternal(key, param, results).catch((error) => {
@@ -258,8 +255,8 @@ function cogniAsync<
           );
         });
       }
-      myResults.push(results[key].then((value) => [key, value]));
-    }
+      return [key, await results[key]] as const;
+    });
     const resolvedResults = await Promise.all(myResults);
     return Object.fromEntries(resolvedResults) as ResultObject<TResult>;
   }


### PR DESCRIPTION
I am using this library to do a lot of long-running API calls, quite a few of which have no interdependency and can thus be executed in parallel. However, the existing implementation enforces sequential execution, leading to longer overall execution time.

I have adapted the execution so that, where possible, computations are parallelized. The resulting code passes the existing test suite (with the minor modification of calling `jest.advanceTimersByTimeAsync()` instead of the synchronous variant).

Sorry for the large diff, it seems like prettier didn't like the whitespace. I can try to revert that part if it bothers you, but it should conform to your prettier settings now.